### PR TITLE
Fix wrong ticks distribution

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -548,8 +548,8 @@ module.exports = function(Chart) {
 
 			if (timestamps.length) {
 				timestamps = arrayUnique(timestamps).sort(sorter);
-				min = Math.min(min, timestamps[0]);
-				max = Math.max(max, timestamps[timestamps.length - 1]);
+				min = min === MAX_INTEGER ? timestamps[0] : min;
+				max = max === MIN_INTEGER ? timestamps[timestamps.length - 1] : max;
 			}
 
 			// In case there is no valid min/max, let's use today limits


### PR DESCRIPTION
Fix wrong ticks distribution when time.min and/or time.max are beyond the visible part of a chart.

Code to reproduce:
var options = myChart.scales['timescale'].options;
options.time.min = start;
options.time.max = end;
myChart.update(0);

Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq